### PR TITLE
Use the new DALL-E 2 API for image generation, instead of Craiyon.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "firebase-admin": "^8.13.0",
         "jimp": "^0.16.1",
         "mkdirp": "^1.0.4",
+        "openai": "^3.1.0",
         "profanease": "^1.1.2",
         "typescript": "^4.4.4"
       },
@@ -7132,6 +7133,36 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/openai": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/openai/-/openai-3.1.0.tgz",
+      "integrity": "sha512-v5kKFH5o+8ld+t0arudj833Mgm3GcgBnbyN9946bj6u7bvel4Yg6YFz2A4HLIYDzmMjIo0s6vSG9x73kOwvdCg==",
+      "dependencies": {
+        "axios": "^0.26.0",
+        "form-data": "^4.0.0"
+      }
+    },
+    "node_modules/openai/node_modules/axios": {
+      "version": "0.26.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.26.1.tgz",
+      "integrity": "sha512-fPwcX4EvnSHuInCMItEhAGnaSEXRBjtzh9fOtsE6E1G6p7vl7edEeZe11QHf18+6+9gR5PbKV/sGKNaD8YaMeA==",
+      "dependencies": {
+        "follow-redirects": "^1.14.8"
+      }
+    },
+    "node_modules/openai/node_modules/form-data": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/optimist": {
@@ -15569,6 +15600,35 @@
       "optional": true,
       "requires": {
         "mimic-fn": "^2.1.0"
+      }
+    },
+    "openai": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/openai/-/openai-3.1.0.tgz",
+      "integrity": "sha512-v5kKFH5o+8ld+t0arudj833Mgm3GcgBnbyN9946bj6u7bvel4Yg6YFz2A4HLIYDzmMjIo0s6vSG9x73kOwvdCg==",
+      "requires": {
+        "axios": "^0.26.0",
+        "form-data": "^4.0.0"
+      },
+      "dependencies": {
+        "axios": {
+          "version": "0.26.1",
+          "resolved": "https://registry.npmjs.org/axios/-/axios-0.26.1.tgz",
+          "integrity": "sha512-fPwcX4EvnSHuInCMItEhAGnaSEXRBjtzh9fOtsE6E1G6p7vl7edEeZe11QHf18+6+9gR5PbKV/sGKNaD8YaMeA==",
+          "requires": {
+            "follow-redirects": "^1.14.8"
+          }
+        },
+        "form-data": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+          "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+          "requires": {
+            "asynckit": "^0.4.0",
+            "combined-stream": "^1.0.8",
+            "mime-types": "^2.1.12"
+          }
+        }
       }
     },
     "optimist": {

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "firebase-admin": "^8.13.0",
     "jimp": "^0.16.1",
     "mkdirp": "^1.0.4",
+    "openai": "^3.1.0",
     "profanease": "^1.1.2",
     "typescript": "^4.4.4"
   },


### PR DESCRIPTION
Note: in order to implement this, we'll need to generate a permanent API key and register our use case with OpenAI.

There's some cost associated with that (about $0.15 per imagine prompt under the current configuration). They also want a demo video to make sure we aren't doing crimes with their service.